### PR TITLE
Travis CI - php 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - nightly
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
 install: composer install
 script: ./vendor/bin/phpunit --coverage-clover clover.xml
 after_success: ./vendor/bin/coveralls -v


### PR DESCRIPTION
Fixes #1 

Travis CI now also run on PHP 7.2.
I also add PHP last buid(allowed failure)